### PR TITLE
Change building abbreviations to upper case

### DIFF
--- a/dining_vcf_generator.py
+++ b/dining_vcf_generator.py
@@ -84,18 +84,18 @@ def addBuildingID(attrib, entry):
     # @todo: the names from uhds don't exactly map to a location due to spelling
     zone = attrib["summary"].encode('utf-8').replace('Zone: ', '')
     parent_building_map = {
-        'Austin Hall': 'Aust',
-        'Dixon Recreation Center': 'DxRC',
+        'Austin Hall': 'AUST',
+        'Dixon Recreation Center': 'DXRC',
         'International Living-Learning Center': 'ILLC',
         'Kelley Engineering Center': 'KEC',
         'Linus Pauling Science Center': 'LPSC',
-        'Marketplace West': 'WsDn',
-        'McNary Dining': 'McNy',
+        'Marketplace West': 'WSDN',
+        'McNary Dining': 'MCNY',
         'Memorial Union': 'MU',
-        'Southside Station @ Arnold': 'ArnD',
-        'The Learning Innovation Center': 'LInC',
-        'Valley Library': 'VLib',
-        'Weatherford Hall': 'Wfd',
+        'Southside Station @ Arnold': 'ARND',
+        'The Learning Innovation Center': 'LINC',
+        'Valley Library': 'VLIB',
+        'Weatherford Hall': 'WFD',
     }
     entry.x_d_bldg_id.value = parent_building_map[zone]
 

--- a/dublabs/util.py
+++ b/dublabs/util.py
@@ -63,7 +63,7 @@ def getVcard(attrib):
 
     if "abbreviation" in attrib and attrib["abbreviation"] is not None:
         entry.add("X-D-BLDG-ID")
-        entry.x_d_bldg_id.value = attrib["abbreviation"]
+        entry.x_d_bldg_id.value = attrib["abbreviation"].upper()
 
     return entry
 


### PR DESCRIPTION
ECSOPS-77

We store the building foreign key in banner using the abbreviation.
In Banner we use uppercase for the building abbreviation, so these
vcf files must match that.

The dining locations script has a manual static map of locations
because from dining we don't have a consistent name / map to locations.
The data we get from dining has slightly different building names or
abbreviations which make it not possible to map.
